### PR TITLE
chore: rename job so existing ruleset can be used

### DIFF
--- a/.github/workflows/ruby-gem-build.yaml
+++ b/.github/workflows/ruby-gem-build.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    name: Build
+    name: Preflight Check
     runs-on: ubuntu-22.04
     strategy:
       matrix:


### PR DESCRIPTION
### Why
We have an org-wide ruleset for our ruby gems that requires the `Build & Publish / Preflight Check (3.X)` jobs pass, we should modify the job name to match so we don't need an entirely new ruleset to target our public rubygem repos

### What is changing
- Change job name to match existing rule set