### PR TITLE
feat: add postgres service container support

### DIFF
--- a/.github/workflows/ruby-gem-build.yaml
+++ b/.github/workflows/ruby-gem-build.yaml
@@ -4,6 +4,11 @@ name: Ruby Gem Build & Publish
 on:
   workflow_call:
     inputs:
+      postgres_image:
+        description: "Sets the 'services.postgres.image' job argument for jobs that need a DB. This determines the image of postgres to be used (e.g. postgres:14-alpine)."
+        default: "" # empty indicates it should not start service
+        required: false
+        type: string
       ruby-versions:
         description: "A stringified JSON array of ruby versions to test this gem with"
         default: '["3.2", "3.3"]'
@@ -16,6 +21,16 @@ concurrency:
 
 jobs:
   build:
+    services:
+      postgres:
+        image: ${{ inputs.postgres_image }}
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        options: >-
+          --health-cmd pg_isready --health-interval 5s --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     name: Preflight Check
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/ruby-gem-build.yaml
+++ b/.github/workflows/ruby-gem-build.yaml
@@ -50,6 +50,10 @@ jobs:
       - name: Lint
         run: bundle exec rubocop
 
+      - name: Setup Postgres Database
+        if: ${{ inputs.postgres_image != '' }}
+        run: bundle exec rake db:setup
+
       - name: Test
         run: bundle exec rspec
 


### PR DESCRIPTION
### Why
Some ruby gems (`eventsimple`) require a postgres image for running their unit tests

### What is changing
- Add postgres service container (if desired)
- Run `db:setup` rake task (if needed)