### PR TITLE
ci: use variable for default runs-on value [skip deploy]

### DIFF
--- a/.github/workflows/ruby-gem-build.yaml
+++ b/.github/workflows/ruby-gem-build.yaml
@@ -32,7 +32,7 @@ jobs:
         ports:
           - 5432:5432
     name: Preflight Check
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.DEFAULT_RUNS_ON }}
     strategy:
       matrix:
         ruby-version: ${{ fromJSON(inputs.ruby-versions) }}
@@ -61,7 +61,7 @@ jobs:
     name: Release
     if: github.ref_name == 'main'
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.DEFAULT_RUNS_ON }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -101,7 +101,7 @@ jobs:
 
   slack_failures:
     name: Notify Slack on Failure
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.DEFAULT_RUNS_ON }}
     if: always() && github.ref_name == 'main' && contains(needs.*.result, 'failure')
     needs:
       - build


### PR DESCRIPTION
### Why

The `ubuntu-latest` label is is moving to Ubuntu 24 starting Dec 5th, 2024.

We are changing repositories to use an org-wide variable currently set to `ubuntu-22.04`.

- Ubuntu 22 is an LTS release and should remain supported until 2027.
- Using an org-wide actions variable makes it easier to mass-migrate repos in the future, while still making it relatively easy to customize per-repo, if necessary, using a repostory-level variable to override the org-wide one.

### What Changed

- Replace usage of `ubuntu-latest` / `ubuntu-22.04` with `${{ vars.DEFAULT_RUNS_ON }}` in workflow files
