### PR TITLE
chore: update supported ruby versions

### DIFF
--- a/.github/workflows/ruby-gem-build.yaml
+++ b/.github/workflows/ruby-gem-build.yaml
@@ -11,7 +11,7 @@ on:
         type: string
       ruby-versions:
         description: "A stringified JSON array of ruby versions to test this gem with"
-        default: '["3.2", "3.3"]'
+        default: '["3.3", "3.4"]'
         required: false
         type: string
 


### PR DESCRIPTION
### Why
Ruby 3.4 is available, Ruby 3.2 will be deprecated soon so we should updated our supported Ruby versions.

### What is changing
- Removed Ruby 3.2
- Added Ruby 3.4