### PR TITLE
chore: update codeowners to new platform teams [skip deploy]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @wealthsimple/build-platform
+* @wealthsimple/delivery-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @wealthsimple/backend-platform
+* @wealthsimple/build-platform


### PR DESCRIPTION
## Why

This PR updates the CODEOWNERS file to use the new Platform Engineering team structure.

⚠️ **This PR was created by a script!** Please review the changes carefully and merge if appropriate! ⚠️

## Changes

- Replaced @wealthsimple/backend-platform with @wealthsimple/build-platform

## Ticket

- Jira: PLB-89
